### PR TITLE
Add `workflow_dispatch` to the workflow

### DIFF
--- a/.github/workflows/slice.yml
+++ b/.github/workflows/slice.yml
@@ -4,6 +4,7 @@ on:
   push:
   schedule:
     - cron:  '0 0 * * *'
+  workflow_dispatch:
 
 jobs:
   build:


### PR DESCRIPTION
Things added/changed:

- Add `workflow_dispatch` to the workflow.
 - This will let us run the workflow any time we want in case needed.
